### PR TITLE
topページ用mangaコンポーネント作成

### DIFF
--- a/src/components/manga-ichiran.tsx
+++ b/src/components/manga-ichiran.tsx
@@ -1,6 +1,6 @@
 import { comaList } from "@/lib/dummy-data";
 import Image from "next/image";
-import Manga from "./manga";
+import TopManga from "./top-manga";
 
 type Props = {
 	title: string;
@@ -18,7 +18,7 @@ export default function MangaIchiran({ title }: Props) {
 			<div className="grid grid-cols-3 gap-9">
 				{[...new Array(6)].map((_, i) => (
 					// biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
-					<Manga title="こんにちは" comaList={comaList} key={i} />
+					<TopManga comaList={comaList} key={i} />
 				))}
 			</div>
 		</div>

--- a/src/components/manga.tsx
+++ b/src/components/manga.tsx
@@ -64,7 +64,6 @@ export default function Manga({ title, comaList }: Props) {
 					</div>
 				</div>
 			</Swiper>
-			<p className="text-3 text-[#808080]">宮沢賢治先生・2022/11/07</p>
 		</div>
 	);
 }

--- a/src/components/top-manga.tsx
+++ b/src/components/top-manga.tsx
@@ -1,0 +1,20 @@
+import Manga from './manga'
+
+type Coma = {
+	text: string;
+	imageUrl: string;
+};
+
+
+type Props = {
+    comaList: Coma[];
+}
+
+export default function TopManga({comaList}: Props) {
+    return (
+        <article>
+            <Manga title="こんにちは" comaList={comaList} />
+            <p className="text-3 text-[#808080]">宮沢賢治先生yo・2022/11/07</p>
+        </article>
+    )
+}


### PR DESCRIPTION
## 実装内容
mangaコンポーネントを漫画部分とユーザ名・投稿日部分の2つに分け、さらにトップページ用のmangaコンポーネントであるTopMangaコンポーネントを作成しました。

## スクショ
<img width="425" alt="スクリーンショット 2024-11-07 17 47 07" src="https://github.com/user-attachments/assets/4ec23799-8d3e-41a8-9c47-df19bb1bca21">

## issue

## 懸念点
型ComaをTopMangaコンポーネントとMangaコンポーネントでそれぞれ定義しているのは微妙かもです。