### PR TITLE
galleryMangaコンポーネント作成

### DIFF
--- a/src/components/gallery-manga.tsx
+++ b/src/components/gallery-manga.tsx
@@ -1,0 +1,24 @@
+import Manga from './manga'
+import { FaRegTrashAlt } from "react-icons/fa";
+
+type Coma = {
+	text: string;
+	imageUrl: string;
+};
+
+
+type Props = {
+    comaList: Coma[];
+}
+
+export default function GalleryManga({comaList}: Props) {
+    return (
+        <article>
+            <Manga title="こんにちは" comaList={comaList} />
+            <div className='flex justify-between'>
+                <time dateTime='2022-11-07'>2022/11/07</time>
+                <FaRegTrashAlt className="transition-colors duration-200 hover:text-red-400" />
+            </div>
+        </article>
+    )
+}


### PR DESCRIPTION
## 実装内容
ギャラリーページ用のMangaコンポーネントを作成しました。ゴミ箱アイコンはホバーすると赤くなるようにしておきました。

## スクショ
<img width="419" alt="スクリーンショット 2024-11-07 18 09 59" src="https://github.com/user-attachments/assets/713f1c27-f13b-44f5-82d6-30fa78661a9f">

## issue
close #39 

## 懸念点