### PR TITLE
サブタイトルをコンポーネント化

### DIFF
--- a/src/app/(pages)/gallery/page.tsx
+++ b/src/app/(pages)/gallery/page.tsx
@@ -1,7 +1,7 @@
 import { auth } from "@/auth";
 import GalleryManga from "@/components/gallery-manga";
+import SubTitle from "@/components/sub-title";
 import { getAllMyComics } from "@/data/comic";
-import Image from "next/image";
 import { redirect } from "next/navigation";
 
 export default async function Page() {
@@ -10,20 +10,8 @@ export default async function Page() {
 	const allMyComics = await getAllMyComics(session.user?.id as string);
 	console.log(allMyComics);
 	return (
-		<div className="container mx-auto">
-			<h2 className="relative">
-				<Image
-					className="pointer-events-none mx-auto select-none"
-					src="/gallery-fukidashi.png"
-					width={534}
-					height={127}
-					alt=""
-				/>
-				<div className="absolute top-[46%] left-[50%] w-full translate-x-[-50%] translate-y-[-50%] text-center">
-					<p className="font-bold text-3xl sm:text-4xl">自分でつくった作品</p>
-				</div>
-			</h2>
-
+		<div className="container mx-auto pt-[50px]">
+			<SubTitle title="自分が作った作品" />
 			<div className="mx-auto my-7 grid w-[95%] grid-cols-1 gap-9 md:grid-cols-3">
 				{allMyComics.map((myComic, i) => (
 					// biome-ignore lint/suspicious/noArrayIndexKey: <explanation>

--- a/src/components/gallery-manga.tsx
+++ b/src/components/gallery-manga.tsx
@@ -24,6 +24,7 @@ export default function GalleryManga({ myComic }: Props) {
 	const { comic } = myComic;
 	const { title, contents, publishedAt } = comic;
 	const formatedPublishedAt = format(publishedAt, "yyyy/MM/dd");
+
 	return (
 		<article>
 			<Manga title={title} contents={contents} />

--- a/src/components/manga-ichiran.tsx
+++ b/src/components/manga-ichiran.tsx
@@ -1,5 +1,5 @@
 import type { SelectComic, SelectUser } from "@/db/schema";
-import Image from "next/image";
+import SubTitle from "./sub-title";
 import TopManga from "./top-manga";
 
 type Props = {
@@ -12,12 +12,7 @@ type ComicType = { comic: SelectComic } & { user: SelectUser | null };
 export default function MangaIchiran({ title, comicsWithAuthor }: Props) {
 	return (
 		<div className="container mx-auto pt-[100px]">
-			<div className="relative mb-[45px] flex justify-center">
-				<Image src="/title-kirinuki.png" width={500} height={100} alt="" />
-				<h3 className="absolute top-[50%] left-[50%] translate-x-[-50%] translate-y-[-65%] font-bold text-[30px]">
-					{title}
-				</h3>
-			</div>
+			<SubTitle title={title} />
 			<div className="grid grid-cols-3 gap-9">
 				{comicsWithAuthor.map((comicWithAuthor, i) => (
 					// biome-ignore lint/suspicious/noArrayIndexKey: <explanation>

--- a/src/components/sub-title.tsx
+++ b/src/components/sub-title.tsx
@@ -1,0 +1,16 @@
+import Image from "next/image";
+
+type Props = {
+	title: string;
+};
+
+export default function SubTitle({ title }: Props) {
+	return (
+		<div className="relative mb-[45px] flex justify-center">
+			<Image src="/title-kirinuki.png" width={500} height={100} alt="" />
+			<h3 className="absolute top-[50%] left-[50%] translate-x-[-50%] translate-y-[-65%] font-bold text-[30px]">
+				{title}
+			</h3>
+		</div>
+	);
+}


### PR DESCRIPTION
## 実装内容
サブタイトルをコンポーネント化

## スクショ
<img width="1512" alt="スクリーンショット 2024-11-09 0 04 03" src="https://github.com/user-attachments/assets/5543d43d-01a5-4281-8b5f-de8a64a334e3">

## issue
close 

## 懸念点
