### PR TITLE
いいねのuiを追加

### DIFF
--- a/src/components/top-manga.tsx
+++ b/src/components/top-manga.tsx
@@ -1,5 +1,6 @@
 import type { SelectComic, SelectUser } from "@/db/schema";
 import { format } from "date-fns";
+import { CiHeart } from "react-icons/ci";
 import Manga from "./manga";
 
 type Props = {
@@ -13,9 +14,15 @@ export default function TopManga({ comicWithAuthor }: Props) {
 	return (
 		<article>
 			<Manga title={title} contents={contents} />
-			<p className="text-3 text-[#808080]">
-				{user?.name}先生・{format(publishedAt, "yyyy/MM/dd")}
-			</p>
+			<div className="flex justify-between">
+				<p className="text-3 text-[#808080]">
+					{user?.name}先生・{format(publishedAt, "yyyy/MM/dd")}
+				</p>
+				<div className="flex items-center gap-3">
+					<p className="text-3 text-[#808080]">xxxx</p>
+					<CiHeart />
+				</div>
+			</div>
 		</article>
 	);
 }


### PR DESCRIPTION
## 実装内容

top-mangaのいいねのuiを設置

## スクショ

<img width="457" alt="スクリーンショット 2024-11-10 20 17 14" src="https://github.com/user-attachments/assets/13e1a434-0b78-40e1-be16-ab41ce0eda24">

## issue
close 

## 懸念点
