### PR TITLE
写真投稿部のバリデーションバグ修正

### DIFF
--- a/src/components/post-new.tsx
+++ b/src/components/post-new.tsx
@@ -37,7 +37,12 @@ export default function PostNew({ onImageUploadSuccess, getComicsData }: Props) 
 
 	const handleImageChange = (index: number, event: ChangeEvent<HTMLInputElement>) => {
 		const file = event.target.files?.[0];
-		if (file) {
+
+        if (!file) {
+            console.log("No file selected")
+            setImageUrls(prevImageUrls => prevImageUrls.map((url, i) => i === index ? null : url));
+        } else {
+            console.log("File selected:", file);
 			// フォーム用
 			const newImages = [...form.getValues("images")];
 			newImages[index] = file;


### PR DESCRIPTION
## 実装内容
/newページの写真選択画面で、写真を選択した後キャンセルボタンを押すと、プレビューに写真が表示されているにも関わらず投稿するボタンが押せなくなるバグを修正しました。

## スクショ

## issue
close #68 

## 懸念点
