### PR TITLE
fix: next.config.mjsのdomainにsupabaseを追加

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
 	images: {
+		domains: ["rxovnhiscvdvedeupiat.supabase.co"],
 		remotePatterns: [
 			{
 				protocol: "https",


### PR DESCRIPTION
## 実装内容
以下を追加
	images: {
		domains: ["rxovnhiscvdvedeupiat.supabase.co"],
		remotePatterns: [
			{
				protocol: "https",
				hostname: "**", // すべてのホストを許可
			},
		],
	},
## スクショ

## issue
close 

## 懸念点
