### PR TITLE
モーダルのレスポンシブ化

### DIFF
--- a/src/components/gallery-manga.tsx
+++ b/src/components/gallery-manga.tsx
@@ -42,7 +42,7 @@ export default function GalleryManga({ myComic }: Props) {
 						<FaRegTrashAlt className="transition-colors duration-200 hover:text-red-400" />
 					</DialogTrigger>
 
-					<DialogContent className="w-[600px]">
+					<DialogContent className="w-[95%] max-w-[600px] rounded-md">
 						<DialogTitle className="mx-auto text-center">作品の削除</DialogTitle>
 						<FaRegTrashAlt className="mx-auto mt-[30px] mb-[20px] text-9xl text-black" />
 						<div className="mb-[20px] text-center">

--- a/src/components/manga-dialog.tsx
+++ b/src/components/manga-dialog.tsx
@@ -19,9 +19,9 @@ export default function MangaDialog({ children, comicWithAuthor }: Props) {
 	return (
 		<Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
 			<DialogTrigger className="w-full">{children}</DialogTrigger>
-			<DialogContent className="w-full">
+			<DialogContent className="w-[95%] rounded-md">
 				<DialogTitle className="text-center">作品の閲覧</DialogTitle>
-				<div className="mx-auto w-[450px]">
+				<div className="mx-auto w-[300px] sm:w-[450px]">
 					<Manga title={title} contents={contents} />
 				</div>
 				<Button className="mx-auto w-[250px] font-bold" onClick={() => setIsDialogOpen(false)}>

--- a/src/components/post-edit.tsx
+++ b/src/components/post-edit.tsx
@@ -290,14 +290,14 @@ export default function PostEdit({ comics, onEditCompleted, backToNew, userId }:
 											</Button>
 										</DialogTrigger>
 
-										<DialogContent className="w-full rounded-md">
+										<DialogContent className="h-[95svh] max-h-[700px] w-[95%] overflow-y-auto rounded-md">
 											<DialogTitle className="mx-auto text-center">作品の公開</DialogTitle>
 											<div className="text-center text-black">
 												<p className="font-bold text-2xl md:text-4xl">最終確認をしよう！</p>
 												<p className="mt-2">これを公開してもいいかな？</p>
 											</div>
-
-											<div className="mx-auto w-[450px]">
+											
+											<div className="mx-auto w-[300px] sm:w-[450px]">
 												<Manga
 													title={title}
 													contents={[
@@ -309,14 +309,14 @@ export default function PostEdit({ comics, onEditCompleted, backToNew, userId }:
 												/>
 											</div>
 
-											<div className="mx-auto w-full rounded-md bg-gray-300 p-4 text-center">
+											<div className="mx-auto w-[300px] rounded-md bg-gray-300 p-4 text-center sm:w-[450px]">
 												<p>公開される情報</p>
 												<ul>
 													<li className="mt-2">・アカウントの表示名</li>
 												</ul>
 											</div>
 
-											<div className="mx-auto grid w-full grid-cols-1 gap-2 md:grid-cols-2">
+											<div className="mx-auto grid w-[300px] grid-cols-1 gap-2 sm:w-[450px] md:grid-cols-2">
 												<Button
 													type="submit"
 													variant="default"


### PR DESCRIPTION
## 実装内容
作品の閲覧、作品の削除、作品の公開の3つのモーダルをレスポンシブ化しました。
iPhone SEのみ画面の高さが足りないので、適宜縦スクロールになるようにしてます。

## スクショ
<img width="440" alt="スクリーンショット 2024-11-15 22 44 03" src="https://github.com/user-attachments/assets/3301503f-ad7e-46ac-b550-139b000eecda">
<img width="441" alt="スクリーンショット 2024-11-15 22 43 14" src="https://github.com/user-attachments/assets/40aa7534-b375-4dd2-8ed0-90da1ceb6367">
<img width="465" alt="スクリーンショット 2024-11-15 22 42 57" src="https://github.com/user-attachments/assets/14401c22-0a5c-4d18-9d87-56c2c7858cc5">

## issue
close 

## 懸念点
